### PR TITLE
Add schedules_parameters to set non-default cron parameters

### DIFF
--- a/src/pargo/argo_types/cron.py
+++ b/src/pargo/argo_types/cron.py
@@ -1,16 +1,13 @@
 from __future__ import annotations
 
-from typing import Literal, TypeAlias
+from typing import Literal
 
 from pydantic import BaseModel
 
 from .primitives import (
     Metadata,
-    Parameter,
 )
 from .workflows import WorkflowSpec
-
-ParameterMap: TypeAlias = dict[str, list[Parameter]] | None
 
 
 class CronWorkflowSpec(BaseModel):

--- a/src/pargo/workflow.py
+++ b/src/pargo/workflow.py
@@ -61,6 +61,10 @@ class Workflow(BaseModel):
         default=None,
         description="Set scheduled execution. Creates an additional cron-manifest when provided.",
     )
+    schedules_parameters: dict[str, Any] | None = Field(
+        default=None,
+        description="Input parameters to the workflow when triggered by schedules. Applied to all schedules runs. If None, `parameters` is applied.",
+    )
     secrets: list[str] | None = Field(default=None, description="")
     trigger_on: Workflow | Condition | None = Field(
         default=None,
@@ -200,12 +204,22 @@ class Workflow(BaseModel):
 
     def to_yaml_cron(self, path):  # FIXME write_cron_yaml/manifest?
         """Write manifest for scheduled execution on Argo Workflows."""
+        if self.schedules_parameters:
+            arguments = {
+                "parameters": [
+                    {"name": k, "value": dumps(v)}
+                    for k, v in self.schedules_parameters.items()
+                ]
+            }
+        else:
+            arguments = None
+
         wf = CronWorkflow(
             metadata=Metadata(name=self.name),
             spec=CronWorkflowSpec(
                 schedules=self.schedules,
                 workflowSpec=WorkflowSpec(
-                    workflowTemplateRef=TemplateRef(name=self.name)
+                    workflowTemplateRef=TemplateRef(name=self.name), arguments=arguments
                 ),
             ),
         )

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -151,6 +151,26 @@ def test_workflow_schedule(tmp_path):
         lint_yaml(tmp_path)
 
 
+def test_workflow_schedule_parameters(tmp_path):
+    """Test that Workflow.to_yaml produces an additional cron-yaml with parameters"""
+    testflow = Workflow.new(
+        "testflow",
+        parameters={"x": "parameter set in parameter"},
+        schedules=["0 0 0 * *"],
+        schedules_parameters={"x": "parameter set in schedules parameter"},
+    ).next(double)
+
+    yaml_path = tmp_path / "testflow-cron.yaml"
+    testflow.to_yaml(path=tmp_path)
+    assert yaml_path.exists()
+    data = yaml_path.read_text()
+    assert "CronWorkflow" in data
+    assert "testflow" in data
+    assert "parameter set in schedules parameter" in data
+    if which("argo"):
+        lint_yaml(tmp_path)
+
+
 def test_workflow_trigger_on(tmp_path):
     """Test that Workflow.to_yaml produces an additional sensor-yaml"""
     testflow = Workflow.new("testflow").next(double)


### PR DESCRIPTION
Can now override parameters with cron_parameters, to use other than default parameters for cron jobs. 